### PR TITLE
Extract code parts using prow into functions

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -1077,14 +1077,88 @@ end
 local d_col = {up = 0, down = 0, left = -1, right = 1}
 local d_row = {up = 1, down = -1, left = 0, right = 0}
 
+function Stack.hasPanelsInTopRow(self)
+  local panelRow = panels[self.height]
+  for idx = 1, self.width do
+    if panelRow[idx]:dangerous() then
+      return true
+    end
+  end
+  return false
+end
+
+function Stack.updateDangerBounce(self)
+-- calculate which columns should bounce
+  self.danger = false
+  local panelRow = self.panels[self.height - 1]
+  for idx = 1, self.width do
+    if panelRow[idx]:dangerous() then
+      self.danger = true
+      self.danger_col[idx] = true
+    else
+      self.danger_col[idx] = false
+    end
+  end
+  if self.danger then
+    if self.panels_in_top_row and self.speed ~= 0 and self.match.mode ~= "puzzle" then
+      -- Player has topped out, panels hold the "flattened" frame
+      self.danger_timer = 15
+    elseif self.stop_time == 0 then
+      self.danger_timer = self.danger_timer - 1
+    end
+    if self.danger_timer < 0 then
+      self.danger_timer = 17
+    end
+  end
+end
+-- determine whether to play danger music
+-- Changed this to play danger when something in top 3 rows
+-- and to play normal music when nothing in top 3 or 4 rows
+function Stack.shouldPlayDangerMusic(self)
+  if not self.danger_music then
+    -- currently playing normal music
+    for row = self.height - 2, self.height do
+      local panelRow = self.panels[row]
+      for column = 1, self.width do
+        if panelRow[column].color ~= 0 and panelRow[column].state ~= "falling" or panelRow[column]:dangerous() then
+          if self.shake_time > 0 then
+            return false
+          else
+            return true
+          end
+        end
+      end
+    end
+  else
+    --currently playing danger
+    local minRowForDangerMusic = self.height - 2
+    if config.danger_music_changeback_delay then
+      minRowForDangerMusic = self.height - 3
+    end
+    for row = minRowForDangerMusic, self.height do
+      local panelRow = self.panels[row]
+      if panelRow ~= nil and type(panelRow) == "table" then
+        for column = 1, self.width do
+          if panelRow[column].color ~= 0 then
+            return true
+          end
+        end
+      elseif self.warningsTriggered["Panels Invalid"] == nil then
+        logger.warn("Panels have invalid data in them, please tell your local developer." .. dump(panels, true))
+        self.warningsTriggered["Panels Invalid"] = true
+      end
+    end
+  end
+
+  return false
+end
+
 -- One run of the engine routine.
 function Stack.simulate(self)
   -- Don't run the main logic if the player has simulated past one of the game overs or the time attack time
   if self:game_ended() == false then
     self:prep_first_row()
     local panels = self.panels
-    local width = self.width
-    local height = self.height
     local panel = nil
     local swapped_this_frame = nil
     if self.do_countdown then
@@ -1154,83 +1228,9 @@ function Stack.simulate(self)
       self.stop_time = self.stop_time - 1
     end
 
-    self.panels_in_top_row = false
-    local top_row = self.height
-    --self.displacement%16==0 and self.height or self.height-1
-    do
-      local panelRow = panels[top_row]
-      for idx = 1, width do
-        if panelRow[idx]:dangerous() then
-          self.panels_in_top_row = true
-        end
-      end
-    end
-
-    -- calculate which columns should bounce
-    do
-      self.danger = false
-      local panelRow = panels[self.height - 1]
-      for idx = 1, width do
-        if panelRow[idx]:dangerous() then
-          self.danger = true
-          self.danger_col[idx] = true
-        else
-          self.danger_col[idx] = false
-        end
-      end
-      if self.danger then
-        if self.panels_in_top_row and self.speed ~= 0 and self.match.mode ~= "puzzle" then
-          -- Player has topped out, panels hold the "flattened" frame
-          self.danger_timer = 15
-        elseif self.stop_time == 0 then
-          self.danger_timer = self.danger_timer - 1
-        end
-        if self.danger_timer < 0 then
-          self.danger_timer = 17
-        end
-      end
-    end
-
-    -- determine whether to play danger music
-    -- Changed this to play danger when something in top 3 rows
-    -- and to play casual when nothing in top 3 or 4 rows
-    if not self.danger_music then
-      -- currently playing casual
-      for _, panelRow in pairs({panels[self.height], panels[self.height - 1], panels[self.height - 2]}) do
-        for idx = 1, width do
-          if panelRow[idx].color ~= 0 and panelRow[idx].state ~= "falling" or panelRow[idx]:dangerous() then
-            self.danger_music = true
-            break
-          end
-        end
-      end
-      if self.shake_time > 0 then
-        self.danger_music = false
-      end
-    else
-      --currently playing danger
-      local toggle_back = true
-      -- Normally, change back if nothing is in the top 3 rows
-      local changeback_rows = {panels[self.height], panels[self.height - 1], panels[self.height - 2]}
-      -- But optionally, wait until nothing is in the fourth row
-      if (config.danger_music_changeback_delay) then
-        table.insert(changeback_rows, panels[self.height - 3])
-      end
-      for _, panelRow in pairs(changeback_rows) do
-        if panelRow ~= nil and type(panelRow) == "table" then
-          for idx = 1, width do
-            if panelRow[idx].color ~= 0 then
-              toggle_back = false
-              break
-            end
-          end
-        elseif self.warningsTriggered["Panels Invalid"] == nil then
-          logger.warn("Panels have invalid data in them, please tell your local developer." .. dump(panels, true))
-          self.warningsTriggered["Panels Invalid"] = true
-        end
-      end
-      self.danger_music = not toggle_back
-    end
+    self.panels_in_top_row = self:hasPanelsInTopRow()
+    self:updateDangerBounce()
+    self.danger_music = self:shouldPlayDangerMusic()
 
     if self.displacement == 0 and self.has_risen then
       self.top_cur_row = self.height
@@ -1312,7 +1312,7 @@ function Stack.simulate(self)
     -- Clean up the value we're using to match newly hovering panels
     -- This is pretty dirty :(
     for row = 1, #panels do
-      for col = 1, width do
+      for col = 1, self.width do
         panels[row][col].match_anyway = nil
       end
     end
@@ -1321,11 +1321,10 @@ function Stack.simulate(self)
     -- Timer-expiring actions + falling
     local propogate_fall = {false, false, false, false, false, false}
     local skip_col = 0
-    local fallen_garbage = 0
     local shake_time = 0
     popsize = "small"
     for row = 1, #panels do
-      for col = 1, width do
+      for col = 1, self.width do
         local cntinue = false
         if skip_col > 0 then
           skip_col = skip_col - 1
@@ -1357,12 +1356,17 @@ function Stack.simulate(self)
               end
             end
           elseif (panel.state == "normal" or panel.state == "falling") then
+            -- x_offset relative to the right side of the garbage
             if panel.x_offset == 0 then
-              local panelRow = panels[row - 1]
               local supported = false
+              -- y_offset relative to the bottom of the garbage
               if panel.y_offset == 0 then
+                -- width refers to how wide the garbage is, check if there is support anywhere along the width
                 for i = col, col + panel.width - 1 do
-                  supported = supported or panelRow[i]:support_garbage()
+                  if panels[row - 1][i]:support_garbage() then
+                    supported = true
+                    break
+                  end
                 end
               else
                 supported = not propogate_fall[col]
@@ -1607,7 +1611,7 @@ function Stack.simulate(self)
       local prev_row = self.cur_row
       local prev_col = self.cur_col
       self.cur_row = bound(1, self.cur_row + d_row[self.cur_dir], self.top_cur_row)
-      self.cur_col = bound(1, self.cur_col + d_col[self.cur_dir], width - 1)
+      self.cur_col = bound(1, self.cur_col + d_col[self.cur_dir], self.width - 1)
       if (playMoveSounds and (self.cur_timer == 0 or self.cur_timer == self.cur_wait_time) and (self.cur_row ~= prev_row or self.cur_col ~= prev_col)) then
         if self:shouldChangeSoundEffects() then
           SFX_Cur_Move_Play = 1
@@ -1734,8 +1738,8 @@ function Stack.simulate(self)
 
     self.panels_in_top_row = false
     -- If any dangerous panels are in the top row, garbage should not fall.
-    for col_idx = 1, width do
-      if panels[top_row][col_idx]:dangerous() then
+    for col_idx = 1, self.width do
+      if panels[self.height][col_idx]:dangerous() then
         self.panels_in_top_row = true
       end
     end
@@ -1758,8 +1762,8 @@ function Stack.simulate(self)
     -- end
     
     -- If any panels (dangerous or not) are in rows above the top row, garbage should not fall.
-    for row_idx = top_row + 1, #self.panels do
-      for col_idx = 1, width do
+    for row_idx = self.height + 1, #self.panels do
+      for col_idx = 1, self.width do
         if panels[row_idx][col_idx].color ~= 0 then
           self.panels_in_top_row = true
         end
@@ -2157,9 +2161,8 @@ function Stack.set_game_over(self)
   if self.canvas then
     local popsize = "small"
     local panels = self.panels
-    local width = self.width
     for row = 1, #panels do
-      for col = 1, width do
+      for col = 1, self.width do
         local panel = panels[row][col]
         panel.state = "dead"
         if row == #panels then
@@ -2279,11 +2282,10 @@ end
 -- Removes unneeded rows
 function Stack.remove_extra_rows(self)
   local panels = self.panels
-  local width = self.width
   for row = #panels, self.height + 1, -1 do
     local nonempty = false
     local panelRow = panels[row]
-    for col = 1, width do
+    for col = 1, self.width do
       nonempty = nonempty or (panelRow[col].color ~= 0)
     end
     if nonempty then


### PR DESCRIPTION
As suggested in https://github.com/panel-attack/panel-attack/pull/747#pullrequestreview-1187300910

I did some refactoring on the danger_music part as that one was kind of horrendous to read, from using a helper table to just iterating based on index. It also returns the final truth directly rather than flipping the value back and forth.

For the garbage drop thing I just eliminated the `panelRow` reference by directly referencing panels[row][col] instead as both are already available where it is being used and we don't want necessarily to check the entire row anyway, just the columns that are also covered by garbage.

Additionally I eliminated the locals `width`, `height` and `top_row` as all of them were either already unused or merely a copy of `self.height` or `self.width` that was never written to in order to eliminate confusion over whether that `width`/`height` is different from `self.width`/`self.height` or not.